### PR TITLE
Use shadcn-solid textfield and button components

### DIFF
--- a/installer/docs/components/molecules/form-field.md
+++ b/installer/docs/components/molecules/form-field.md
@@ -4,7 +4,9 @@
 import { FormField } from "@/components/forms/FormField";
 
 <FormField label="Email" helperText="We never share your email.">
-	<input type="email" class="w-full" />
+	<TextFieldRoot>
+		<TextFieldInput type="email" class="w-full" />
+	</TextFieldRoot>
 </FormField>;
 ```
 

--- a/installer/src/components/molecules/steps/Steps.tsx
+++ b/installer/src/components/molecules/steps/Steps.tsx
@@ -16,6 +16,11 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select.tsx";
+import {
+	TextFieldRoot,
+	TextFieldInput,
+	TextFieldLabel,
+} from "@/components/ui/textfield.tsx";
 import { setupStateMachine } from "@/libs/install/state.ts";
 import { createBrowserInspector } from "@statelyai/inspect";
 import { useMachine } from "@xstate/solid";
@@ -161,39 +166,48 @@ export default function Steps() {
 
 				<Match when={(state as any).matches("Config_Editing")}>
 					<div class="space-y-3">
-						<input
-							type="text"
-							name="appEUI"
-							onChange={(t) =>
-								emitEvent({
-									type: "config.changeField",
-									field: "appEUI",
-									value: t.target.value,
-								})
-							}
-						/>
-						<input
-							type="text"
-							name="appKey"
-							onChange={(t) =>
-								emitEvent({
-									type: "config.changeField",
-									field: "appKey",
-									value: t.target.value,
-								})
-							}
-						/>
-						<input
-							type="text"
-							name="devEUI"
-							onChange={(t) =>
-								emitEvent({
-									type: "config.changeField",
-									field: "devEUI",
-									value: t.target.value,
-								})
-							}
-						/>
+						<TextFieldRoot>
+							<TextFieldLabel>appEUI</TextFieldLabel>
+							<TextFieldInput
+								type="text"
+								name="appEUI"
+								onChange={(t) =>
+									emitEvent({
+										type: "config.changeField",
+										field: "appEUI",
+										value: t.target.value,
+									})
+								}
+							/>
+						</TextFieldRoot>
+						<TextFieldRoot>
+							<TextFieldLabel>appKey</TextFieldLabel>
+							<TextFieldInput
+								type="text"
+								name="appKey"
+								onChange={(t) =>
+									emitEvent({
+										type: "config.changeField",
+										field: "appKey",
+										value: t.target.value,
+									})
+								}
+							/>
+						</TextFieldRoot>
+						<TextFieldRoot>
+							<TextFieldLabel>devEUI</TextFieldLabel>
+							<TextFieldInput
+								type="text"
+								name="devEUI"
+								onChange={(t) =>
+									emitEvent({
+										type: "config.changeField",
+										field: "devEUI",
+										value: t.target.value,
+									})
+								}
+							/>
+						</TextFieldRoot>
 						<div class="flex gap-3 pt-2">
 							<Button onClick={() => emitEvent({ type: "config.clear" })}>
 								clear

--- a/installer/src/components/organisms/Newsletter.tsx
+++ b/installer/src/components/organisms/Newsletter.tsx
@@ -1,4 +1,8 @@
 import { Headline } from "@/components/ui/headline";
+import {
+	TextFieldRoot,
+	TextFieldInput,
+} from "@/components/ui/textfield.tsx";
 
 export default function Newsletter() {
 	return (
@@ -21,11 +25,13 @@ export default function Newsletter() {
 						id="form-newsletter"
 						class="flex px-4 py-2 bg-white rounded-full dark:bg-slate-800 focus-within:ring-2 focus-within:ring-cyan-600 hover:ring-2 hover:ring-cyan-600"
 					>
-						<input
-							type="email"
-							class="w-full appearance-none dark:bg-slate-800 focus:outline-none"
-							placeholder="your@email-address.iot"
-						/>
+						<TextFieldRoot class="flex-1">
+							<TextFieldInput
+								type="email"
+								class="w-full appearance-none dark:bg-slate-800 focus:outline-none"
+								placeholder="your@email-address.iot"
+							/>
+						</TextFieldRoot>
 						<button
 							id="button-newsletter"
 							class="px-3 py-1 ml-2 text-sm font-semibold rounded-full text-sky-100 shrink-0 bg-gradient-to-br from-sky-500 to-cyan-400 hover:from-sky-700 hover:to-cyan-600 focus:outline-none focus:ring-2 focus:ring-cyan-300/50"

--- a/installer/src/components/ui/input.tsx
+++ b/installer/src/components/ui/input.tsx
@@ -1,51 +1,56 @@
-import { Component, JSX, splitProps } from "solid-js";
+import type { Component, JSX } from "solid-js";
+import { splitProps } from "solid-js";
 import { cn } from "@/libs/cn";
+import {
+  TextFieldRoot,
+  TextFieldInput,
+  TextFieldLabel,
+  TextFieldDescription,
+  TextFieldErrorMessage,
+} from "@/components/ui/textfield.tsx";
 
 export interface InputProps extends JSX.InputHTMLAttributes<HTMLInputElement> {
   error?: string;
   label?: string;
   helperText?: string;
+  class?: string;
 }
 
 const Input: Component<InputProps> = (props) => {
   const [local, rest] = splitProps(props, ["class", "error", "label", "helperText", "id"]);
-  
+
   const inputId = () => local.id || `input-${Math.random().toString(36).substr(2, 9)}`;
-  const errorId = () => `${inputId()}-error`;
-  const helperId = () => `${inputId()}-helper`;
 
   return (
-    <div class="space-y-2">
+    <TextFieldRoot class="space-y-2">
       {local.label && (
-        <label 
-          for={inputId()} 
-          class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-        >
+        <TextFieldLabel for={inputId()} class="block text-sm font-medium text-gray-700 dark:text-gray-300">
           {local.label}
-        </label>
+        </TextFieldLabel>
       )}
-      <input
+      <TextFieldInput
         {...rest}
         id={inputId()}
         class={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           local.error && "border-red-500 focus-visible:ring-red-500",
-          local.class
+          local.class,
         )}
         aria-invalid={!!local.error}
-        aria-describedby={local.error ? errorId() : local.helperText ? helperId() : undefined}
+        aria-describedby={local.error ? `${inputId()}-error` : local.helperText ? `${inputId()}-helper` : undefined}
       />
-      {local.error && (
-        <p id={errorId()} class="text-sm text-red-600 dark:text-red-400" role="alert">
+      {local.error ? (
+        <TextFieldErrorMessage id={`${inputId()}-error`} class="text-sm text-red-600 dark:text-red-400" role="alert">
           {local.error}
-        </p>
+        </TextFieldErrorMessage>
+      ) : (
+        local.helperText && (
+          <TextFieldDescription id={`${inputId()}-helper`} class="text-sm text-gray-500 dark:text-gray-400">
+            {local.helperText}
+          </TextFieldDescription>
+        )
       )}
-      {local.helperText && !local.error && (
-        <p id={helperId()} class="text-sm text-gray-500 dark:text-gray-400">
-          {local.helperText}
-        </p>
-      )}
-    </div>
+    </TextFieldRoot>
   );
 };
 

--- a/installer/src/components/ui/textfield.tsx
+++ b/installer/src/components/ui/textfield.tsx
@@ -1,0 +1,122 @@
+import { cn } from "@/libs/cn";
+import type { PolymorphicProps } from "@kobalte/core/polymorphic";
+import type {
+  TextFieldDescriptionProps,
+  TextFieldErrorMessageProps,
+  TextFieldInputProps,
+  TextFieldLabelProps,
+  TextFieldProps,
+} from "@kobalte/core/text-field";
+import { TextField as TextFieldPrimitive } from "@kobalte/core/text-field";
+import type { ParentProps, ValidComponent } from "solid-js";
+import { Show, splitProps } from "solid-js";
+
+export const TextField = TextFieldPrimitive;
+
+type textFieldRootProps<T extends ValidComponent = "div"> = ParentProps<
+  TextFieldProps<T> & { class?: string; required?: boolean }
+>;
+
+export const TextFieldRoot = <T extends ValidComponent = "div">(
+  props: PolymorphicProps<T, textFieldRootProps<T>>,
+) => {
+  const [local, rest] = splitProps(props as textFieldRootProps, [
+    "class",
+    "children",
+  ]);
+
+  return (
+    <TextFieldPrimitive
+      class={cn("space-y-2", local.class)}
+      {...rest}
+    >
+      {local.children}
+    </TextFieldPrimitive>
+  );
+};
+
+type textFieldLabelProps<T extends ValidComponent = "label"> = ParentProps<
+  TextFieldLabelProps<T> & { class?: string }
+>;
+
+export const TextFieldLabel = <T extends ValidComponent = "label">(
+  props: PolymorphicProps<T, textFieldLabelProps<T>>,
+) => {
+  const [local, rest] = splitProps(props as textFieldLabelProps, [
+    "class",
+    "children",
+  ]);
+  return (
+    <TextFieldPrimitive.Label
+      class={cn(
+        "block text-sm font-medium text-foreground",
+        local.class,
+      )}
+      {...rest}
+    >
+      {local.children}
+    </TextFieldPrimitive.Label>
+  );
+};
+
+type textFieldInputProps<T extends ValidComponent = "input"> = TextFieldInputProps<T> & {
+  class?: string;
+};
+
+export const TextFieldInput = <T extends ValidComponent = "input">(
+  props: PolymorphicProps<T, textFieldInputProps<T>>,
+) => {
+  const [local, rest] = splitProps(props as textFieldInputProps, ["class"]);
+  return (
+    <TextFieldPrimitive.Input
+      class={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        local.class,
+      )}
+      {...rest}
+    />
+  );
+};
+
+type textFieldDescriptionProps<T extends ValidComponent = "div"> = ParentProps<
+  TextFieldDescriptionProps<T> & { class?: string }
+>;
+
+export const TextFieldDescription = <T extends ValidComponent = "div">(
+  props: PolymorphicProps<T, textFieldDescriptionProps<T>>,
+) => {
+  const [local, rest] = splitProps(props as textFieldDescriptionProps, [
+    "class",
+    "children",
+  ]);
+  return (
+    <TextFieldPrimitive.Description
+      class={cn("text-sm text-muted-foreground", local.class)}
+      {...rest}
+    >
+      {local.children}
+    </TextFieldPrimitive.Description>
+  );
+};
+
+type textFieldErrorMessageProps<T extends ValidComponent = "div"> = ParentProps<
+  TextFieldErrorMessageProps<T> & { class?: string }
+>;
+
+export const TextFieldErrorMessage = <T extends ValidComponent = "div">(
+  props: PolymorphicProps<T, textFieldErrorMessageProps<T>>,
+) => {
+  const [local, rest] = splitProps(props as textFieldErrorMessageProps, [
+    "class",
+    "children",
+  ]);
+  return (
+    <TextFieldPrimitive.ErrorMessage
+      class={cn("text-sm text-destructive", local.class)}
+      {...rest}
+    >
+      {local.children}
+    </TextFieldPrimitive.ErrorMessage>
+  );
+};
+

--- a/installer/src/installer/forms/StepFinishShowingErrorForm.tsx
+++ b/installer/src/installer/forms/StepFinishShowingErrorForm.tsx
@@ -3,6 +3,7 @@ import { FormLayout } from "@/components/forms/FormLayout";
 import { PrimaryButton } from "@/components/forms/PrimaryButton";
 import { SecondaryButton } from "@/components/forms/SecondaryButton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import type { FormProps } from "../types";
 
 export interface StepFinishShowingErrorFormProps extends FormProps {
@@ -143,13 +144,14 @@ const StepFinishShowingErrorForm: Component<StepFinishShowingErrorFormProps> = (
         </div>
 
         <div class="text-center">
-          <button
+          <Button
             type="button"
+            variant="link"
             onClick={handleDismiss}
             class="text-sm text-gray-500 hover:text-gray-700 underline"
           >
             Fehler ignorieren und fortfahren
-          </button>
+          </Button>
         </div>
       </div>
     </FormLayout>


### PR DESCRIPTION
Replace native HTML button with shadcn-solid `Button` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-cfea720e-ddc4-4ddf-86ae-c575b31cd47c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cfea720e-ddc4-4ddf-86ae-c575b31cd47c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

